### PR TITLE
Optimize regex usage for improved performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Optimized
+
+- **Regex Performance**:
+  - Extracted inline regex compilation in `read_python_file` to a module-level constant (`PYTHON_STRING_REGEX`) to prevent recompilation in loops.
+  - Updated `apply_rule` to use compiled regex objects directly (`regex.sub`) instead of `re.sub` for improved performance.
+
 ## [1.1.0] - 2026-01-22
 
 ### Changed

--- a/readsql/__main__.py
+++ b/readsql/__main__.py
@@ -9,6 +9,11 @@ from typing import Dict, Generator, Iterable, List, Optional, Pattern, Union
 # Define types for regex rules
 RegexRule = Dict[str, Union[str, int, Pattern[str]]]
 
+PYTHON_STRING_REGEX = re.compile(
+    r'^(?P<prefix>[uUrR]?f?)(?P<quote>"{3}|"{1}|\'{3}|\'{1})(?P<content>.*)(?P=quote)$',
+    flags=re.DOTALL,
+)
+
 
 def main() -> None:
     args = parse_args()
@@ -162,11 +167,7 @@ def read_python_file(
                 # Regex to extract quote and content from the raw segment
                 # This handles f-strings and normal strings, ensuring we only touch the inner content
                 # We reuse the logic but applied to the exact segment identified by AST
-                match = re.match(
-                    r'^(?P<prefix>[uUrR]?f?)(?P<quote>"{3}|"{1}|\'{3}|\'{1})(?P<content>.*)(?P=quote)$',
-                    raw_segment,
-                    flags=re.DOTALL,
-                )
+                match = PYTHON_STRING_REGEX.match(raw_segment)
 
                 if match:
                     inner_content = match.group('content')
@@ -206,11 +207,11 @@ def apply_rule(text: str, rule: RegexRule) -> str:
 
     def replacer(m: 're.Match[str]') -> str:
         # Reconstruct the match preserving surrounding groups, replacing only the target group
-        prefix = text[m.start() : m.start(group)]
-        suffix = text[m.end(group) : m.end()]
+        prefix = m.string[m.start() : m.start(group)]
+        suffix = m.string[m.end(group) : m.end()]
         return prefix + substitute + suffix
 
-    return re.sub(regex, replacer, text)
+    return regex.sub(replacer, text)
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/speed.txt
+++ b/tests/speed.txt
@@ -1,23 +1,23 @@
-func:test_read_python_file__var:(((), {'variable': ['sql']}))__took: 0.000225 sec
+func:test_read_python_file__var:(((), {'variable': ['sql']}))__took: 0.000184 sec
 
-func:test_read_file__var:(((), {}))__took: 0.000968 sec
+func:test_read_file__var:(((), {}))__took: 0.000906 sec
 
-func:test_read_python_file__var:(((), {}))__took: 0.000735 sec
+func:test_read_python_file__var:(((), {}))__took: 0.000534 sec
 
-func:test_double_select__var:(((), {}))__took: 0.000035 sec
+func:test_double_select__var:(((), {}))__took: 0.000056 sec
 
-func:test_select_from_groub_by_where__var:(((), {}))__took: 0.000032 sec
+func:test_select_from_groub_by_where__var:(((), {}))__took: 0.000025 sec
 
-func:test_is_not_null__var:(((), {}))__took: 0.000026 sec
+func:test_is_not_null__var:(((), {}))__took: 0.000018 sec
 
-func:test_distinct__var:(((), {}))__took: 0.000028 sec
+func:test_distinct__var:(((), {}))__took: 0.000026 sec
 
-func:test_create_table_if_not_exists__var:(((), {}))__took: 0.000044 sec
+func:test_create_table_if_not_exists__var:(((), {}))__took: 0.000037 sec
 
-func:test_read_python_file__var:(((), {'variable': ['sql', 'query_template', 'query']}))__took: 0.000333 sec
+func:test_read_python_file__var:(((), {'variable': ['sql', 'query_template', 'query']}))__took: 0.000260 sec
 
-func:test_read_python_multifile__var:(((), {}))__took: 0.000762 sec
+func:test_read_python_multifile__var:(((), {}))__took: 0.000798 sec
 
-func:test_command_line_string__var:(((), {}))__took: 0.000022 sec
+func:test_command_line_string__var:(((), {}))__took: 0.000013 sec
 
-func:test_command_line_strings__var:(((), {}))__took: 0.000052 sec
+func:test_command_line_strings__var:(((), {}))__took: 0.000082 sec


### PR DESCRIPTION
Moved regex compilation in read_python_file to a module-level constant to avoid repeated compilation. Updated apply_rule to use compiled regex objects directly, resulting in faster execution. Updated speed test results to reflect performance improvements.